### PR TITLE
Untitled

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -532,7 +532,7 @@ namespace MonoTouch.Dialog
 				
 		public override UITableViewCell GetCell (UITableView tv)
 		{
-			var cell = tv.DequeueReusableCell (value == null ? skey : skeyvalue);
+			var cell = tv.DequeueReusableCell (Value == null ? skey : skeyvalue);
 			if (cell == null){
 				cell = new UITableViewCell (Value == null ? UITableViewCellStyle.Default : UITableViewCellStyle.Value1, skey);
 				cell.SelectionStyle = (Tapped != null) ? UITableViewCellSelectionStyle.Blue : UITableViewCellSelectionStyle.None;


### PR DESCRIPTION
With different Elements (e.g. StringElement and MultiLineElement) it could happen that the StringElement got a cell with "Default" and MultilineElement a cell with "Value1" - which is wrong

I fixed it for my specific Problem, but i think a property would be the best way to handle the style changes
