### PR TITLE
Change to index sample

### DIFF
--- a/Sample/DemoIndex.cs
+++ b/Sample/DemoIndex.cs
@@ -33,7 +33,7 @@ namespace Sample
 		
 		string [] GetSectionTitles ()
 		{
-			return (from section in Root select section.Caption).ToArray ();
+			return (from section in Root select section.Caption.Substring(0,1)).ToArray ();
 		}
 		
 		class IndexedSource : Source {


### PR DESCRIPTION
Changed the GetSectionTitles method to return the first char of the string. This makes the index bar look more like the one from Apple's contacts app. For some reason, when you render a longer string it causes that index bar to appear fat and squished. 
