### PR TITLE
Added Advanced Editing Demo

### DIFF
--- a/Sample/DemoEditingAdvanced.cs
+++ b/Sample/DemoEditingAdvanced.cs
@@ -1,0 +1,127 @@
+using System;
+using MonoTouch.Dialog;
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+
+namespace Sample
+{
+	// 
+	// To support editing, you need to subclass the DialogViewController and provide
+	// your own "Source" classes (which you also have to subclass).
+	//
+	// There are two source classes, a sizing one (for elements that have different
+	// sizes, and one for fixed element sizes.   Since we are just using strings,
+	// we are going to take a shortcut and just implement one of the sources.
+	//
+	
+	public class AdvancedEditingDialog : DialogViewController {
+		
+		// This is our subclass of the fixed-size Source that allows editing
+		public class EditingSource : DialogViewController.Source {
+			public EditingSource (DialogViewController dvc) : base (dvc) {}
+			
+			public override bool CanEditRow (UITableView tableView, NSIndexPath indexPath)
+			{
+				// Trivial implementation: we let all rows be editable, regardless of section or row
+				return true;
+			}
+			
+			public override UITableViewCellEditingStyle EditingStyleForRow (UITableView tableView, NSIndexPath indexPath)
+			{
+				// trivial implementation: show a delete button always
+				return UITableViewCellEditingStyle.Delete;
+			}
+			
+			public override void CommitEditingStyle (UITableView tableView, UITableViewCellEditingStyle editingStyle, NSIndexPath indexPath)
+			{
+				//
+				// In this method, we need to actually carry out the request
+				//
+				var section = Container.Root [indexPath.Section];
+				var element = section [indexPath.Row];
+				section.Remove (element);
+			}
+		}
+		
+		public override Source CreateSizingSource (bool unevenRows)
+		{
+			if (unevenRows)
+				throw new NotImplementedException ("You need to create a new SourceSizing subclass, this sample does not have it");
+			return new EditingSource (this);
+		}
+		
+		public AdvancedEditingDialog (RootElement root, bool pushing) : base (root, pushing)
+		{
+		}
+	}	
+		
+	public partial class AppDelegate
+	{		
+		public void DemoAdvancedEditing () 
+		{
+			var root = new RootElement ("Todo list") {
+				new Section() {
+			        new StringElement ("1", "Todo item 1"),
+					new StringElement ("2","Todo item 2"),
+					new StringElement ("3","Todo item 3"),
+					new StringElement ("4","Todo item 4"),
+					new StringElement ("5","Todo item 5")
+				}
+		    };
+			var dvc = new AdvancedEditingDialog (root, true);
+			AdvancedConfigEdit (dvc);			
+			navigation.PushViewController (dvc, true);
+		}
+		
+		void AdvancedConfigEdit (DialogViewController dvc)
+		{
+			dvc.NavigationItem.RightBarButtonItem = new UIBarButtonItem (UIBarButtonSystemItem.Edit, delegate {
+				// Activate editing
+				// Switch the root to editable elements		
+				dvc.Root = CreateEditableRoot(dvc.Root, true);
+				dvc.ReloadData();	
+				// Activate row editing & deleting
+				dvc.TableView.SetEditing (true, true);
+				AdvancedConfigDone(dvc);				
+			});
+		}
+
+		void AdvancedConfigDone (DialogViewController dvc)
+		{
+			dvc.NavigationItem.RightBarButtonItem = new UIBarButtonItem (UIBarButtonSystemItem.Done, delegate {
+				// Deactivate editing
+				dvc.ReloadData();
+				// Switch updated entry elements to StringElements
+				dvc.Root = CreateEditableRoot(dvc.Root, false);
+				dvc.TableView.SetEditing (false, true);
+				AdvancedConfigEdit (dvc);
+			});
+		}
+		
+		RootElement CreateEditableRoot (RootElement root, bool editable)
+		{
+		    var rootElement = new RootElement("Todo list") {
+				new Section()
+			};
+			
+			foreach (var element in root[0].Elements) {
+				if(element is StringElement) {
+					rootElement[0].Add(CreateEditableElement (element.Caption, (element as StringElement).Value, editable));
+				} else {
+					rootElement[0].Add(CreateEditableElement (element.Caption, (element as EntryElement).Value, editable));
+				}
+			}
+			
+		    return rootElement;
+		}
+		
+		Element CreateEditableElement (string caption, string content, bool editable)
+		{
+			if (editable) {
+				return new EntryElement(caption, "todo", content);
+			} else {
+				return new StringElement(caption, content);
+			}
+		}
+	}
+}

--- a/Sample/Main.cs
+++ b/Sample/Main.cs
@@ -41,6 +41,7 @@ namespace Sample
 					new StyledStringElement ("Styled Elements", DemoStyled) { BackgroundUri = new Uri ("file://" + p) },
 					new StringElement ("Load More Sample", DemoLoadMore),
 					new StringElement ("Row Editing Support", DemoEditing),
+					new StringElement ("Advanced Editing Support", DemoAdvancedEditing),
 					new StringElement ("Owner Drawn Element", DemoOwnerDrawnElement),
 				},
 				new Section ("Container features"){

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -108,6 +108,7 @@
     <Compile Include="DemoRefresh.cs" />
     <Compile Include="DemoContainerStyle.cs" />
     <Compile Include="DemoIndex.cs" />
+    <Compile Include="DemoEditingAdvanced.cs" />
   </ItemGroup>
   <ItemGroup>
     <Page Include="MainWindow.xib" />


### PR DESCRIPTION
Added this demo based on your answer to [my question](http://stackoverflow.com/questions/5316544/monotouch-dialog-advanced-editing) on stackoverflow.

Simple todo list that is initially read-only with StringElements, until the edit button is clicked, then we flip the items to EntryElements. When the user is done, we convert the changed items back to StringElements.

I think the CreateEditableRoot method could use some refactoring. I don't think the way I'm fetching the value of the incoming element is proper.
