### PR TITLE
Reflection API will use Caption attribute on Enum values if pressent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 *.userprefs
 *.pidb
+bin
+obj

--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -343,7 +343,19 @@ namespace MonoTouch.Dialog
 						if (v == evalue)
 							selected = idx;
 						
-						csection.Add (new RadioElement (MakeCaption (fi.Name)));
+						string enumCaption = null;
+						object[] enumAttrs = fi.GetCustomAttributes(false);
+						foreach(object attr in enumAttrs){
+							if(attr is CaptionAttribute) {
+								enumCaption = ((CaptionAttribute)attr).Caption;
+								break;
+							}							
+						}
+						
+						if(string.IsNullOrEmpty(enumCaption))
+							enumCaption = MakeCaption(fi.Name);
+												
+						csection.Add (new RadioElement (enumCaption));
 						idx++;
 					}
 					

--- a/Sample/DemoReflectionApi.cs
+++ b/Sample/DemoReflectionApi.cs
@@ -35,6 +35,9 @@ namespace Sample
 		[Caption ("Favorite CLR type")]
 		public TypeCode FavoriteType;
 		
+		[Caption ("Make a selection")]
+		public Options SelectedOption;
+		
 	[Section ("Checkboxes")]
 		[Checkbox]
 		bool English = true;
@@ -56,6 +59,16 @@ namespace Sample
 		[RadioSelection ("ListOfString")] 
 		public int selected = 1;
 		public IList<string> ListOfString;
+	}
+	
+	public enum Options
+	{
+		[Caption("Option 1")]
+		Option1,
+		[Caption("Option 2")]		
+		Option2,
+		[Caption("Option 3")]
+		Option3
 	}
 
 	public class TimeSettings {
@@ -111,11 +124,12 @@ namespace Sample
 				    "Birthday:        {4}\n" +
 				    "Alarm:           {5}\n" +
 				    "Favorite Type:   {6}\n" + 
-				    "IEnumerable idx: {7}", 
+				    "IEnumerable idx: {7}\n" +
+					"Selected option: {8}",
 				    settings.AccountEnabled, settings.Login, settings.Password, 
 				    settings.TimeSamples.Appointment, settings.TimeSamples.Birthday, 
 				    settings.TimeSamples.Alarm, settings.FavoriteType,
-				    settings.selected);
+				    settings.selected, settings.SelectedOption);
 			};
 			navigation.PushViewController (dv, true);	
 		}


### PR DESCRIPTION
Added support for the Caption-attribute on enum members. When generating a radio section for an enum it will use the value of the Caption attribute if pressent, if not it will generate a caption based on the enum name. Also added a new field to demonstrate this feature in the DemoReflectionApi sample.
