### PR TITLE
Removed Thread.Sleep() before image download 

### DIFF
--- a/MonoTouch.Dialog/Utilities/ImageLoader.cs
+++ b/MonoTouch.Dialog/Utilities/ImageLoader.cs
@@ -299,7 +299,7 @@ namespace MonoTouch.Dialog.Utilities
 			do {
 				bool downloaded = false;
 				
-				System.Threading.Thread.Sleep (5000);
+				//System.Threading.Thread.Sleep (5000);
 				downloaded = Download (uri, target);
 				if (!downloaded)
 					Console.WriteLine ("Error fetching picture for {0} to {1}", uri, target);


### PR DESCRIPTION
Is the "System.Threading.Thread.Sleep (5000);" on line 302 really necessary ? I commented it out in my project and images download way much faster.
