### PR TITLE
Small update to EntyElement to make it simpler to initialize when using LINQ

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1188,7 +1188,17 @@ namespace MonoTouch.Dialog
 		/// this to use this for numeric input, email addressed,
 		/// urls, phones.
 		/// </summary>
-		public UIKeyboardType KeyboardType = UIKeyboardType.Default;
+		public UIKeyboardType KeyboardType {
+			get {
+				return keyboardType;
+			}
+			set {
+				keyboardType = value;
+				if (entry != null)
+					entry.KeyboardType = value;
+			}
+		}
+		public UIKeyboardType keyboardType = UIKeyboardType.Default;
 		
 		static NSString ekey = new NSString ("EntryElement");
 		bool isPassword, becomeResponder;


### PR DESCRIPTION
Made the EntryElements' KeyboardType into a property so that it supports LINQ
