### PR TITLE
Add entry element features

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1296,6 +1296,8 @@ namespace MonoTouch.Dialog
 		string placeholder;
 		static UIFont font = UIFont.BoldSystemFontOfSize (17);
 		public UITextAutocapitalizationType AutocapitalizationType = UITextAutocapitalizationType.Sentences;
+		public UIReturnKeyType ReturnKeyType = UIReturnKeyType.Default;
+		public event EventHandler Go;
 		public event EventHandler Changed;
 		
 		/// <summary>
@@ -1437,18 +1439,24 @@ namespace MonoTouch.Dialog
 						focus.BecomeFirstResponder (true);
 					else 
 						focus.ResignFirstResponder (true);
-					
+
+					if (Go != null && entry.ReturnKeyType == UIReturnKeyType.Go) {
+						Go(this, EventArgs.Empty);
+					}
+
 					return true;
 				};
 				entry.Started += delegate {
 					EntryElement self = null;
-					var returnType = UIReturnKeyType.Default;
-					
-					foreach (var e in (Parent as Section).Elements){
-						if (e == this)
-							self = this;
-						else if (self != null && e is EntryElement)
-							returnType = UIReturnKeyType.Next;
+					var returnType = ReturnKeyType;
+
+					if (returnType != UIReturnKeyType.Default) {
+						foreach (var e in (Parent as Section).Elements){
+							if (e == this)
+								self = this;
+							else if (self != null && e is EntryElement)
+								returnType = UIReturnKeyType.Next;
+						}
 					}
 					entry.ReturnKeyType = returnType;
 				};


### PR DESCRIPTION
Using the EntryElement for username/password fields in a login dialog box. To avoid the auto-correction in the username field I've added the UITextAutocapitalizationType. In order to enable the 'Go' key on the password field to trigger an action (in this case, login) I've added the 'Go' event and call it from the delegate attached to ShouldReturn. 

FWIW, the code was actually written by a coworker [jwuatredpoint](https://github.com/jwuatredpoint) but wasn't done in a pull-request-capable way at the time, so I'm sort of submitting on his behalf :)
