### PR TITLE
Added hooks for extending the Reflection API for custom data types and Elements

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -2608,7 +2608,11 @@ namespace MonoTouch.Dialog
 				
 				cell = new UITableViewCell (style, rkey);
 				cell.SelectionStyle = UITableViewCellSelectionStyle.Blue;
-			} 
+			}
+
+			// The check is needed because the cell might have been recycled.
+			if (cell.DetailTextLabel != null)
+				cell.DetailTextLabel.Text = "";
 		
 			cell.TextLabel.Text = Caption;
 			var radio = group as RadioGroup;

--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -450,13 +450,18 @@ namespace MonoTouch.Dialog
 						
 						SetValue (mi, obj, fi.GetValue (null));
 					}
-				} else SetValue (mi, obj, FetchElementValue (element));
+				} else {
+					object Value;
+					if(FetchElementValue(element, out Value))
+						SetValue (mi, obj, Value);
+				}
 			}
 		}
 
-		public virtual object FetchElementValue (Element element)
+		public virtual bool FetchElementValue (Element element, out object Value)
 		{
-			return null;
+			Value = null;
+			return false;
 		}
 	}
 }

--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -372,7 +372,7 @@ namespace MonoTouch.Dialog
 							break;
 						}
 					}
-				} else if ((element = BuildElementForType (mType, caption, GetValue (mi, o), attrs)) == null) {
+				} else if ((element = BuildElementForType (mType, caption, GetValue (mi, o), attrs, callbacks)) == null) {
 					var nested = GetValue (mi, o);
 					if (nested != null){
 						var newRoot = new RootElement (caption);
@@ -389,7 +389,7 @@ namespace MonoTouch.Dialog
 			root.Add (section);
 		}
 
-		public virtual Element BuildElementForType(Type mType, string Caption, object Value, object[] attrs)
+		public virtual Element BuildElementForType(Type mType, string Caption, object Value, object[] attrs, object callbacks)
 		{
 			return null;
 		}

--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -372,7 +372,7 @@ namespace MonoTouch.Dialog
 							break;
 						}
 					}
-				} else if ((element = BuildElementForType (mType, caption, GetValue (mi, o))) == null) {
+				} else if ((element = BuildElementForType (mType, caption, GetValue (mi, o), attrs)) == null) {
 					var nested = GetValue (mi, o);
 					if (nested != null){
 						var newRoot = new RootElement (caption);
@@ -389,7 +389,7 @@ namespace MonoTouch.Dialog
 			root.Add (section);
 		}
 
-		public virtual Element BuildElementForType (Type mType, string Caption, object Value)
+		public virtual Element BuildElementForType(Type mType, string Caption, object Value, object[] attrs)
 		{
 			return null;
 		}

--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -372,7 +372,7 @@ namespace MonoTouch.Dialog
 							break;
 						}
 					}
-				} else {
+				} else if ((element = BuildElementForType (mType, caption, GetValue (mi, o))) == null) {
 					var nested = GetValue (mi, o);
 					if (nested != null){
 						var newRoot = new RootElement (caption);
@@ -387,6 +387,11 @@ namespace MonoTouch.Dialog
 				mappings [element] = new MemberAndInstance (mi, o);
 			}
 			root.Add (section);
+		}
+
+		public virtual Element BuildElementForType (Type mType, string Caption, object Value)
+		{
+			return null;
 		}
 		
 		class MemberRadioGroup : RadioGroup {
@@ -445,8 +450,13 @@ namespace MonoTouch.Dialog
 						
 						SetValue (mi, obj, fi.GetValue (null));
 					}
-				}
+				} else SetValue (mi, obj, FetchElementValue (element));
 			}
+		}
+
+		public virtual object FetchElementValue (Element element)
+		{
+			return null;
 		}
 	}
 }

--- a/README.markdown
+++ b/README.markdown
@@ -865,6 +865,55 @@ This works for most elements, but not for the StringElement and StyledStringElem
 as those use their own set of keys for various rendering scenarios.   You would have
 to replicate the code in those classes.
 
+Extending the Reflection API for your own custom Elements
+---------------------------------------------------------
+
+To use custom Elements with the Reflection API you will need to create a custom 
+data type to hold values and a subclass of BindingContext. In your custom 
+BindingContext class you will need to override these two methods:
+
+		public virtual Element BuildElementForType (Type mType, string Caption, object Value)
+		public virtual object FetchElementValue (Element element)
+
+Here is a very simple example:
+
+	    class MyCustomDataType
+	    {
+	        public int CustomData;
+	    }
+
+	    class BindingContextEx : BindingContext
+	    {
+	        public BindingContextEx (object callbacks, object o, string title) : base(callbacks, o, title) { }
+
+	        public override Element BuildElementForType(Type mType, string Caption, object Value)
+	        {
+	            if (mType == typeof(MyCustomDataType))
+	            {
+	                return new MyCustomElement(Caption, (MyCustomDataType)Value);
+	            }
+
+	            return base.BuildElementForType(mType, Caption, Value);
+	        }
+
+	        public override object FetchElementValue(Element element)
+	        {
+	            if (element.GetType() == typeof(MyCustomElement))
+	            {
+	                return ((MyCustomElement)element).Value;
+	            }
+
+	            return base.FetchElementValue(element);
+	        }
+	    }
+
+This would allow you to use custom views that bind to custom data types using 
+the reflection API. Your custom Element would handle the mechanics of building 
+the table cell that used those custom views and binding to your data types.
+	
+Once this is done you can add your custom data types as members of the object 
+being edited.
+
 Customizing the DialogViewController
 ====================================
 

--- a/Sample/DemoReflectionExtensionApi.cs
+++ b/Sample/DemoReflectionExtensionApi.cs
@@ -1,0 +1,178 @@
+//
+// Sample showing the Extension Reflection-based API to create a dialog
+//
+using System;
+using System.Collections.Generic;
+using MonoTouch.Dialog;
+using MonoTouch.UIKit;
+using MonoTouch.Foundation;
+using System.Drawing;
+using MonoTouch.CoreGraphics;
+
+namespace Sample
+{
+	// Use the preserve attribute to inform the linker that even if I do not
+	// use the fields, to not try to optimize them away.
+	
+	[Preserve (AllMembers=true)]
+	class ExtensionSettings {
+	
+	[Section("Reflection Extension")]
+		[Caption("Custom Data Type")]
+		public CustomDataType custom;
+	}
+
+	public class CustomDataType {
+		public int value;
+
+		public override string ToString() {
+			return value.ToString();
+		}
+	}
+
+	class CustomElement : Element
+	{
+		static MonoTouch.Foundation.NSString key = new MonoTouch.Foundation.NSString("CustomElement");
+
+		CustomControl ui;
+
+		public CustomDataType Value
+		{
+			get { return new CustomDataType() { value = ui.Value }; }
+			set { ui.Value = value.value; }
+		}
+
+		public CustomElement(string Caption, CustomDataType Value)
+			: base(Caption)
+		{
+			ui = new CustomControl(new RectangleF(0, 0, 90, 20));
+			this.Value = Value;
+		}
+
+		protected override MonoTouch.Foundation.NSString CellKey
+		{
+			get {
+				return key;
+			}
+		}
+
+		public override UITableViewCell GetCell(UITableView tv)
+		{
+			var cell = tv.DequeueReusableCell(CellKey);
+			if (cell == null) {
+				cell = new UITableViewCell(UITableViewCellStyle.Default, CellKey);
+				cell.SelectionStyle = UITableViewCellSelectionStyle.None;
+			} else
+				RemoveTag(cell, 1);
+
+			cell.TextLabel.Text = Caption;
+			cell.AccessoryView = ui;
+
+			return cell;
+		}
+	}
+
+	class BindingContextEx : BindingContext
+	{
+		public BindingContextEx(object callbacks, object o, string title) : base(callbacks, o, title) { }
+
+		public override Element BuildElementForType(Type mType, string Caption, object Value)
+		{
+			if (mType == typeof(CustomDataType)) {
+				return new CustomElement(Caption, (CustomDataType)Value);
+			}
+
+			return base.BuildElementForType(mType, Caption, Value);
+		}
+
+		public override bool FetchElementValue(Element element, out object Value)
+		{
+			if (element.GetType() == typeof(CustomElement)) {
+				Value = ((CustomElement)element).Value;
+				return true;
+			}
+
+			return base.FetchElementValue(element, out Value);
+		}
+	}
+
+	class CustomControl : UIView
+	{
+		UIButton left, right;
+		UILabel text;
+
+		private int _Value;
+		public int Value
+		{
+			get { return _Value; }
+			set { _Value = value; text.Text = _Value.ToString();  }
+		}
+
+		public CustomControl(RectangleF frame)
+			: base(frame)
+		{
+			BackgroundColor = UIColor.Clear;
+
+			float controlwidth = frame.Width / 3f;
+			RectangleF controlframe = new RectangleF(frame.X, frame.Y, controlwidth, frame.Height);
+
+			left = UIButton.FromType(UIButtonType.RoundedRect);
+			left.Frame = controlframe;
+			left.SetTitle("+", UIControlState.Normal);
+			left.TouchUpInside += delegate {
+				Value++;
+			};
+
+			controlframe.Offset(controlwidth, 0);
+			text = new UILabel(controlframe) {
+				TextAlignment = UITextAlignment.Center,
+				Text = Value.ToString()
+			};
+			text.Layer.BorderColor = UIColor.Black.CGColor;
+			text.Layer.BorderWidth = 1f;
+
+			controlframe.Offset(controlwidth, 0);
+			right = UIButton.FromType(UIButtonType.RoundedRect);
+			right.Frame = controlframe;
+			right.SetTitle("-", UIControlState.Normal);
+			right.TouchUpInside += delegate {
+				Value--;
+			};
+
+			this.AddSubviews(left, text, right);
+		}
+	}
+	
+	public partial class AppDelegate 
+	{
+		ExtensionSettings ExtensionSettings;
+		
+		public void DemoReflectionExtensionApi ()
+		{
+			if (ExtensionSettings == null) {
+				ExtensionSettings = new ExtensionSettings() {
+					custom = new CustomDataType() {
+						value = 1
+					}
+				};
+			}
+
+			var bc = new BindingContextEx(null, ExtensionSettings, "Settings");
+			
+			var dv = new DialogViewController (bc.Root, true);
+			
+			// When the view goes out of screen, we fetch the data.
+			dv.ViewDissapearing += delegate {
+				// This reflects the data back to the object instance
+				bc.Fetch ();
+				
+				// Manly way of dumping the data.
+				Console.WriteLine ("Current status:");
+				Console.WriteLine (
+				    "CustomDataType:  {0}\n",
+					ExtensionSettings.custom.ToString()); 
+			};
+			navigation.PushViewController (dv, true);	
+		}
+	}
+}

--- a/Sample/DemoReflectionExtensionApi.cs
+++ b/Sample/DemoReflectionExtensionApi.cs
@@ -76,13 +76,13 @@ namespace Sample
 	{
 		public BindingContextEx(object callbacks, object o, string title) : base(callbacks, o, title) { }
 
-		public override Element BuildElementForType(Type mType, string Caption, object Value)
+		public override Element BuildElementForType(Type mType, string Caption, object Value, object[] attrs, object callbacks)
 		{
 			if (mType == typeof(CustomDataType)) {
 				return new CustomElement(Caption, (CustomDataType)Value);
 			}
 
-			return base.BuildElementForType(mType, Caption, Value);
+			return base.BuildElementForType(mType, Caption, Value, attrs, callbacks);
 		}
 
 		public override bool FetchElementValue(Element element, out object Value)

--- a/Sample/Main.cs
+++ b/Sample/Main.cs
@@ -50,7 +50,8 @@ namespace Sample
 					new StringElement ("Index sample", DemoIndex),
 				},
 				new Section ("Auto-mapped", footer){
-					new StringElement ("Reflection API", DemoReflectionApi)
+					new StringElement ("Reflection API", DemoReflectionApi),
+					new StringElement ("Reflection Extension API", DemoReflectionExtensionApi),
 				},
 			};
 

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -89,9 +89,10 @@
     <Compile Include="DemoContainerStyle.cs" />
     <Compile Include="DemoIndex.cs" />
     <Compile Include="DemoEditingAdvanced.cs" />
+    <Compile Include="DemoReflectionExtensionApi.cs" />
   </ItemGroup>
   <ItemGroup>
-    <InterfaceDefinition Include="MainWindow.xib" xmlns="" />
+    <InterfaceDefinition Include="MainWindow.xib" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonoTouch.Dialog\MonoTouch.Dialog.csproj">


### PR DESCRIPTION
I added some hooks for extending the Reflection API. It's a simple design that I used for when I had custom UI views that I wanted to bind to custom data value types. This allowed me to continue to use the reflection API data binding yet still get custom UI in a simple way.

It might be interesting to use these hooks for the basis of all Element building and value fetching to make the system more flexible (but I did not do that here).
