### PR TITLE
EntryElement, UIViewElement and RootElement enhancements

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1341,7 +1341,7 @@ namespace MonoTouch.Dialog
 
 		UIKeyboardType keyboardType = UIKeyboardType.Default;
 		UIReturnKeyType? returnKeyType = null;
-		UITextAutocapitalizationType autocapitalizationType = UITextAutocapitalizationType.AllCharacters;
+		UITextAutocapitalizationType autocapitalizationType = UITextAutocapitalizationType.None;
 		UITextAutocorrectionType autocorrectionType = UITextAutocorrectionType.Default;
 		bool isPassword, becomeResponder;
 		UITextField entry;


### PR DESCRIPTION
**EntryElement**

Changed the default AutoCapitalizationType on EntryElement to None from AllCharacters - it was creating an ALL CAPS field.

Scroll the UITableView to centre the active UITextField on the screen when the user taps inside the UITextField. Suitable for when the UITextField would be hidden by the keyboard when it appears.

Make the EntryElement the first responder (show the keyboard and place the cursor in the UITextField) when the UITableViewCell itself is tapped.

**UIViewElement**

Set the caption text on a UIViewElement.

**RootElement**

Raise a Tapped event when the user taps a RootElement. The RootElement otherwise behaves as it should.
