### PR TITLE
Add `SkipNonPublicAttribute` to skip all non-public fields/properties.

### DIFF
--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -50,6 +50,9 @@ namespace MonoTouch.Dialog
 	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, Inherited=false)]
 	public class SkipAttribute : Attribute {}
 	
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct, Inherited=false)]
+	public class SkipNonPublicAttribute : Attribute {}
+	
 	[AttributeUsage (AttributeTargets.Field | AttributeTargets.Property, Inherited=false)]
 	public class PasswordAttribute : EntryAttribute {
 		public PasswordAttribute (string placeholder) : base (placeholder) {}
@@ -199,8 +202,11 @@ namespace MonoTouch.Dialog
 		void Populate (object callbacks, object o, RootElement root)
 		{
 			MemberInfo last_radio_index = null;
-			var members = o.GetType ().GetMembers (BindingFlags.DeclaredOnly | BindingFlags.Public |
-							       BindingFlags.NonPublic | BindingFlags.Instance);
+			
+			BindingFlags flags = BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance;
+			if (Attribute.GetCustomAttribute(o.GetType (), typeof(SkipNonPublicAttribute)) == null)
+				flags |= BindingFlags.NonPublic;
+			var members = o.GetType ().GetMembers (flags);
 
 			Section section = null;
 			


### PR DESCRIPTION
Hey, I noticed that MT.Dialog automatically uses all properties and fields of a class when building the `RootElement` via reflection. As I used it for a class that has internal (private) fields for the public properties, I had all values in the generated dialog twice.

So instead of adding `[Skip]` to every single private field, I wanted something more global to apply to the class declaration and simply ignore all private fields. As such I created the `SkipNonPublic` attribute, that does exactly that. When populating the `RootElement`, it simply checks if that attribute is present for the class and if that’s the case then `BindingFlags.NonPublic` won’t be used for reading the properties/fields of the type.

It might be useful to extend this later on, so you can force separate fields/properties to appear regardless of that attribute, but I didn’t need that in this case.

Tell me what you think.
poke
