### PR TITLE
Private properties are not accessible.

### DIFF
--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -137,7 +137,7 @@ namespace MonoTouch.Dialog
 				return fi.GetValue (o);
 			var pi = mi as PropertyInfo;
 			
-			var getMethod = pi.GetGetMethod ();
+			var getMethod = pi.GetGetMethod (true);
 			return getMethod.Invoke (o, new object [0]);
 		}
 
@@ -149,7 +149,7 @@ namespace MonoTouch.Dialog
 				return;
 			}
 			var pi = mi as PropertyInfo;
-			var setMethod = pi.GetSetMethod ();
+			var setMethod = pi.GetSetMethod (true);
 			setMethod.Invoke (o, new object [] { val });
 		}
 			


### PR DESCRIPTION
When declaring private properties, with private getters or setters, then MT.D crashes with a NPE as it retrieves non-existent public getters/setters.

The attached commit fixes that in a very simple way, by requesting private getters/setters if necessary.
