### PR TITLE
Skip compiler-generated fields.

### DIFF
--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -214,9 +214,9 @@ namespace MonoTouch.Dialog
 				object [] attrs = mi.GetCustomAttributes (false);
 				bool skip = false;
 				foreach (var attr in attrs){
-					if (attr is SkipAttribute)
+					if (attr is SkipAttribute || attr is System.Runtime.CompilerServices.CompilerGeneratedAttribute)
 						skip = true;
-					if (attr is CaptionAttribute)
+					else if (attr is CaptionAttribute)
 						caption = ((CaptionAttribute) attr).Caption;
 					else if (attr is SectionAttribute){
 						if (section != null)


### PR DESCRIPTION
Auto properties generate internal backing fields to store the actual value of the property. These backing fields are visible via reflection as private fields. As such, when reading properties in MT.D, you usually end up with both the properties and its internal backing fields (which have a generic name and cannot get any metadata via attributes).

As such it makes sense to skip all compiler-generated fields, i.e. backing fields. The attached commit simply does this by skipping the field if `CompilerGeneratedAttribute` was set for that field. `CompilerGeneratedAttribute` is automatically set by the compiler, and cannot be set by the user, so it is safe to never include those fields.
