### PR TITLE
Use CaptionAttribute for enum values if available.

### DIFF
--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -343,7 +343,8 @@ namespace MonoTouch.Dialog
 						if (v == evalue)
 							selected = idx;
 						
-						csection.Add (new RadioElement (MakeCaption (fi.Name)));
+						CaptionAttribute ca = Attribute.GetCustomAttribute(fi, typeof(CaptionAttribute)) as CaptionAttribute;
+						csection.Add (new RadioElement (ca != null ? ca.Caption : MakeCaption (fi.Name)));
 						idx++;
 					}
 					


### PR DESCRIPTION
Enum titles are currently based solely on the member name. To allow adding more information for the user, and separate the internal names from the representation to the user, it makes sense to allow setting the `CaptionAttribute` for enum members.

The attached commit checks if an explicit caption was set, and otherwise falls back to the default behaviour.
