### PR TITLE
Fix bug where if a DVC is opened as a modal, date-fields become unusable...

### DIFF
--- a/MonoTouch.Dialog/DialogViewController.cs
+++ b/MonoTouch.Dialog/DialogViewController.cs
@@ -463,10 +463,10 @@ namespace MonoTouch.Dialog
 			dirty = true;
 			
 			var parent = ParentViewController;
-			var nav = parent as UINavigationController;
+			var nav = parent as UINavigationController; 
 			
 			// We can not push a nav controller into a nav controller
-			if (nav != null && !(controller is UINavigationController))
+			if (nav != null && nav.ModalViewController == null && !(controller is UINavigationController))
 				nav.PushViewController (controller, true);
 			else
 				PresentModalViewController (controller, true);


### PR DESCRIPTION
....

This resolves an issue where if you open a DialogViewController as a
modal window using PresentModalViewController on a NavigationController
date-fields would be unusable (would not open on device), and if you
got them open (simulator) ou couldn't close them again. This resolves a
general problem with DialogViewController::Activate. Also, on the
date-picker viewcontroller/screen I've added a green glass button with
the text "Ok" (notchangeablee at present) to enable the user to go back
should there be need for it (no navigation-controller present).
