### PR TITLE
Added EventHandler to EntryElement to make clearing UI elements easier

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1376,6 +1376,7 @@ namespace MonoTouch.Dialog
 
 		public event EventHandler Changed;
 		public event Func<bool> ShouldReturn;
+		public EventHandler EntryStarted {get;set;}
 		/// <summary>
 		/// Constructs an EntryElement with the given caption, placeholder and initial value.
 		/// </summary>
@@ -1538,6 +1539,10 @@ namespace MonoTouch.Dialog
 						entry.ReturnKeyType = returnKeyType.Value;
 
 					tv.ScrollToRow (IndexPath, UITableViewScrollPosition.Middle, true);
+					
+					if (EntryStarted != null) {
+						EntryStarted(this, null);
+					}
 				};
 			}
 			if (becomeResponder){


### PR DESCRIPTION
In the EntryElement class I added an "EntryStarted" EventHandler that is fired when the "Started" event of the UITextField is fired. This is useful for clearing other UI elements like say a UIPicker when they lose focus. See example of how it's used here: 
https://github.com/crdeutsch/MonoTouch.Dialog-PickerElement
