### PR TITLE
Modified the reflection API so that by default string lists are displayed as a picker list sliding from the bottom.

### DIFF
--- a/MonoTouch.Dialog/DialogViewController.cs
+++ b/MonoTouch.Dialog/DialogViewController.cs
@@ -247,6 +247,11 @@ namespace MonoTouch.Dialog
 			ReloadData ();
 		}
 		
+		public override void ViewDidLoad ()
+		{
+			base.ViewDidLoad ();
+		}
+		
 		public virtual void SearchButtonClicked (string text)
 		{
 		}

--- a/MonoTouch.Dialog/Elements/PickerElement.cs
+++ b/MonoTouch.Dialog/Elements/PickerElement.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+
+namespace MonoTouch.Dialog
+{
+	public class PickerElement : StyledStringElement
+	{
+		private bool becomeResponder;
+		private UILabel replacementLabel;
+		private IEnumerable<String> datasource;
+		
+		private static readonly UIFont defaultFont = UIFont.FromName("Helvetica", 16);
+		private static readonly NSString cellkey = new NSString("PickerCell");
+		
+		public PickerElement(string caption, string value, IEnumerable<string> datasource) : base(caption, value)
+		{
+			this.datasource = datasource;
+		}
+		
+		protected override NSString CellKey
+		{
+			get 
+			{ 
+				return cellkey; 
+			}
+		}
+		
+		protected virtual UILabel CreateReplacementLabel(RectangleF frame)
+		{
+			int selectedIdx = datasource.Select((a, i) => (a.Equals(Value)) ? i : -1).Max();
+			
+			var label = new UIPickerLabel(frame, CreatePicker(), selectedIdx)
+			       	{
+						BackgroundColor = UIColor.Clear,
+			       		AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleLeftMargin,
+			       		Text = Value ?? String.Empty,
+			       		Tag = 1,
+						Font = SubtitleFont ?? defaultFont,
+						AdjustsFontSizeToFitWidth = true,
+						TextAlignment = UITextAlignment.Right,
+						TextColor = DetailColor ?? UIColor.FromRGB(56, 84, 135),
+			       	};
+			
+			return label;
+		}
+		
+		public override UITableViewCell GetCell(UITableView tv)
+		{
+			var cell = tv.DequeueReusableCell(CellKey);
+			if (cell == null)
+			{
+				cell = new UITableViewCell(UITableViewCellStyle.Default, CellKey);
+				cell.SelectionStyle = UITableViewCellSelectionStyle.None;
+			}
+			else
+				RemoveTag(cell, 1);
+			
+			cell.Accessory = UITableViewCellAccessory.DisclosureIndicator;
+			
+			if (replacementLabel == null)
+			{
+				SizeF size = this.ComputeEntryPosition(tv, cell);
+				float yOffset = (cell.ContentView.Bounds.Height - size.Height)/2 - 1;
+				float width = cell.ContentView.Bounds.Width - size.Width;
+				
+				replacementLabel = CreateReplacementLabel(new RectangleF(size.Width + 5, yOffset, width - 10, size.Height));
+			}
+			
+			if (becomeResponder)
+			{
+				replacementLabel.BecomeFirstResponder();
+				becomeResponder = false;
+			}
+			
+			cell.TextLabel.Text = Caption;
+			cell.ContentView.AddSubview(replacementLabel);
+			
+			return cell;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+			
+			if (disposing)
+			{
+				if(replacementLabel != null)
+				{
+					replacementLabel.Dispose();
+					replacementLabel = null;
+				}
+			}
+		}
+
+		public virtual UIPickerView CreatePicker()
+		{
+			var picker = new UIPickerView(RectangleF.Empty)
+			             	{
+			             		AutoresizingMask = UIViewAutoresizing.FlexibleWidth,
+			             	};
+		
+			picker.Model = new PickerModel(datasource, (s) => UpdateValue(s));
+			picker.ShowSelectionIndicator = true;
+			
+			return picker;
+		}
+		
+		private SizeF ComputeEntryPosition(UITableView tv, UITableViewCell cell)
+		{
+			var s = this.Parent as Section;
+			if (s.EntryAlignment.Width != 0)
+				return s.EntryAlignment;
+
+			// If all EntryElements have a null Caption, align UITextField with the Caption
+			// offset of normal cells (at 10px).
+			var max = new SizeF(-15, tv.StringSize("M", defaultFont).Height);
+			foreach (var ee in s.Elements)
+			{
+				if (ee.Caption != null)
+				{
+					var size = tv.StringSize(ee.Caption, defaultFont);
+					if (size.Width > max.Width)
+						max = size;
+				}
+			}
+			s.EntryAlignment = new SizeF(25 + Math.Min(max.Width, 160), max.Height);
+			
+			return s.EntryAlignment;
+		}
+		
+		private void UpdateValue(string newValue){
+			
+			if (newValue == Value)
+				return;
+			
+			replacementLabel.Text = Value = newValue;
+		}
+		
+		private class PickerModel: UIPickerViewModel 
+		{
+			IEnumerable<string> datasource;
+			Action<string> callback;
+			
+			public PickerModel (IEnumerable<string> datasource, Action<String> callback)
+			{
+				this.callback = callback;
+				this.datasource = datasource;
+			}
+			
+			public override int GetComponentCount (UIPickerView v)
+            {
+                return 1;
+            }
+    
+            public override int GetRowsInComponent (UIPickerView pickerView, int component)
+            {
+                return datasource.Count ();
+            }
+    
+            public override string GetTitle (UIPickerView picker, int row, int component)
+            {
+                return datasource.ElementAt(row);
+            }
+    
+            public override void Selected (UIPickerView picker, int row, int component)
+            {
+                callback(datasource.ElementAt(row));
+            }
+		}
+		
+		private class UIPickerLabel: UILabel 
+		{
+			UIPickerView inputView;
+			int selectedIdx;
+			UIToolbar inputAccessoryView;
+			
+			public UIPickerLabel (RectangleF frame, UIPickerView picker, int selectedIdx): base(frame)
+			{
+				this.selectedIdx = selectedIdx;
+				this.inputView = picker;
+				UserInteractionEnabled = true;
+				
+				inputAccessoryView = new UIToolbar(new RectangleF(0, 0, 320, 40));
+				inputAccessoryView.Items = new UIBarButtonItem[] {
+					new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace),
+					new UIBarButtonItem(UIBarButtonSystemItem.Done, delegate {
+						ResignFirstResponder();
+					})
+				};
+			}
+
+			public override void TouchesEnded (NSSet touches, UIEvent evt)
+			{
+				inputView.Select(selectedIdx, 0, false);
+				BecomeFirstResponder();
+				
+				base.TouchesEnded (touches, evt);
+			}
+			
+			public override bool CanBecomeFirstResponder 
+			{
+				get 
+				{
+					return true;
+				}
+			}
+			
+			public override UIView InputAccessoryView 
+			{
+				get 
+				{
+					return inputAccessoryView;
+				}
+			}
+			
+			public override UIView InputView 
+			{
+				get 
+				{
+					return inputView;
+				}
+			}
+			
+			protected override void Dispose(bool disposing)
+			{
+				base.Dispose(disposing);
+				if (disposing)
+				{
+					if (inputView != null)
+					{
+						inputView.Dispose();
+						inputView = null;
+					}
+					
+					if (inputAccessoryView != null)
+					{
+						inputAccessoryView.Dispose();
+						inputAccessoryView = null;
+					}
+				}
+			}
+		}
+	}
+}
+

--- a/MonoTouch.Dialog/MonoTouch.Dialog.csproj
+++ b/MonoTouch.Dialog/MonoTouch.Dialog.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Utilities\GlassButton.cs" />
     <Compile Include="Utilities\LocalizationExtensions.cs" />
     <Compile Include="Elements\Json.cs" />
+    <Compile Include="Elements\PickerElement.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Images\" />

--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -359,9 +359,11 @@ namespace MonoTouch.Dialog
 					
 					var datasource = (System.Collections.Generic.IEnumerable<string>)GetValue(mi, o);
 					var selected = (int) GetValue(last_radio_index, o);
+					
 					if (selected >= datasource.Count() || selected < 0)
 						selected = 0;
-					element = new PickerElement(caption, datasource.ElementAt(selected),  datasource);
+					
+					element = new PickerElement(caption, datasource.ElementAt(selected), datasource, last_radio_index);
 					
 					last_radio_index = null;
 				} else if (typeof (System.Collections.IEnumerable).IsAssignableFrom (mType)){
@@ -446,6 +448,9 @@ namespace MonoTouch.Dialog
 					var entry = (EntryElement) element;
 					entry.FetchValue ();
 					SetValue (mi, obj, entry.Value);
+				} else if (element is PickerElement){
+					var entry = (PickerElement) element;
+					SetValue (entry.mi, obj, entry.FetchSelectedIndex());
 				} else if (element is ImageElement)
 					SetValue (mi, obj, ((ImageElement) element).Value);
 				else if (element is RootElement){

--- a/MonoTouch.Dialog/Reflect.cs
+++ b/MonoTouch.Dialog/Reflect.cs
@@ -13,9 +13,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using MonoTouch.UIKit;
+using System.Linq;
 using System.Drawing;
 using MonoTouch.Foundation;
+using MonoTouch.UIKit;
 
 namespace MonoTouch.Dialog
 {
@@ -351,6 +352,18 @@ namespace MonoTouch.Dialog
 					element = new RootElement (caption, new RadioGroup (null, selected)) { csection };
 				} else if (mType == typeof (UIImage)){
 					element = new ImageElement ((UIImage) GetValue (mi, o));
+				} else if (typeof (System.Collections.Generic.IEnumerable<string>).IsAssignableFrom(mType))
+				{
+					if (last_radio_index == null)
+						throw new Exception("IEnumerable found, but no previous int found");
+					
+					var datasource = (System.Collections.Generic.IEnumerable<string>)GetValue(mi, o);
+					var selected = (int) GetValue(last_radio_index, o);
+					if (selected >= datasource.Count() || selected < 0)
+						selected = 0;
+					element = new PickerElement(caption, datasource.ElementAt(selected),  datasource);
+					
+					last_radio_index = null;
 				} else if (typeof (System.Collections.IEnumerable).IsAssignableFrom (mType)){
 					var csection = new Section ();
 					int count = 0;


### PR DESCRIPTION
This only affects the Reflection API string lists IEnumerable<string>.

I've also changed the datetime picker to be a slide from the bottom picker instead of standalone, would you guys be interested in that?

You can see it in action on the Sample Reflection API screen.
