### PR TITLE
Minor tweaks to make PickerElement work better

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1364,11 +1364,23 @@ namespace MonoTouch.Dialog
 					this.autocorrectionType = value;
 			}
 		}
+		
+		public UITextFieldViewMode ClearButtonMode { 
+			get { 
+				return clearButtonMode;
+			}
+			set { 
+				clearButtonMode = value;
+				if (entry != null)
+					entry.ClearButtonMode = value;
+			}
+		}
 
 		UIKeyboardType keyboardType = UIKeyboardType.Default;
 		UIReturnKeyType? returnKeyType = null;
 		UITextAutocapitalizationType autocapitalizationType = UITextAutocapitalizationType.Sentences;
 		UITextAutocorrectionType autocorrectionType = UITextAutocorrectionType.Default;
+		UITextFieldViewMode clearButtonMode = UITextFieldViewMode.Never;
 		bool isPassword, becomeResponder;
 		UITextField entry;
 		string placeholder;
@@ -1457,7 +1469,8 @@ namespace MonoTouch.Dialog
 				Placeholder = placeholder ?? "",
 				SecureTextEntry = isPassword,
 				Text = Value ?? "",
-				Tag = 1
+				Tag = 1,
+				ClearButtonMode = ClearButtonMode
 			};
 		}
 		


### PR DESCRIPTION
I added a couple new features to my PickerElement project including highlighting the current row and scrolling it into view. I also implement a DateTimeElement that doesn't use a sub view.
https://github.com/crdeutsch/MonoTouch.Dialog-PickerElement

I've update the PickerElement to be based off the EntryElement and found being able to override BecomeFirstResponder and ResignFirstResponder useful.

Also I moved the EntryStarted event to the top in order to avoid issues with scrolling the view while the size is still adjusted.
