### PR TITLE
Check to see if tableView.Source is not null

### DIFF
--- a/MonoTouch.Dialog/DialogViewController.cs
+++ b/MonoTouch.Dialog/DialogViewController.cs
@@ -621,11 +621,14 @@ namespace MonoTouch.Dialog
 			// on an implementation detail; the base SectionIndexTitles() method to be implementated
 			// in UITableViewSource.
 			
-			MethodInfo m = tableView.Source.GetType().GetMethod("SectionIndexTitles", BindingFlags.Instance | BindingFlags.Public);
+			if(tableView.Source != null)
+			{
+				MethodInfo m = tableView.Source.GetType().GetMethod("SectionIndexTitles", BindingFlags.Instance | BindingFlags.Public);
 			
-			if (!m.DeclaringType.Name.Equals(typeof(UITableViewSource).Name)) {
-				if (tableView.Source.SectionIndexTitles(tableView).Length > 0) {
-					return true;
+				if (!m.DeclaringType.Name.Equals(typeof(UITableViewSource).Name)) {
+					if (tableView.Source.SectionIndexTitles(tableView).Length > 0) {
+						return true;
+					}
 				}
 			}
 						


### PR DESCRIPTION
SInce the new search change from a week or two back, if tableView.Source is null then we get a null exception and the app running it crashes. This patch prevents this.
