### PR TITLE
Changed MessageElement to allow injection of the cell rendering code via a constructor FactoryMethod.

### DIFF
--- a/MonoTouch.Dialog/Elements/MessageElement.cs
+++ b/MonoTouch.Dialog/Elements/MessageElement.cs
@@ -126,17 +126,17 @@ namespace MonoTouch.Dialog
 		
 	public class MessageElement : Element, IElementSizing
 	{
-		static NSString mKey = new NSString ("MessageElement");
+		protected static NSString mKey = new NSString ("MessageElement");
 		
 		public string Sender, Body, Subject;
 		public DateTime Date;
 		public bool NewFlag;
 		public int MessageCount;
 
-		private MessageSummaryViewFactory m_ViewFactory;
+		protected MessageSummaryViewFactory m_ViewFactory;
 		
-		class MessageCell : UITableViewCell {
-			BaseMessageSummaryView view;
+		protected class MessageCell : UITableViewCell {
+			protected BaseMessageSummaryView view;
 			
 			public MessageCell () : base (UITableViewCellStyle.Default, mKey)
 			{
@@ -153,7 +153,7 @@ namespace MonoTouch.Dialog
 				Accessory = UITableViewCellAccessory.DisclosureIndicator;
 			}
 			
-			public void Update (MessageElement me)
+			public virtual void Update (MessageElement me)
 			{
 				view.Update (me.Sender, me.Body, me.Subject, me.Date, me.NewFlag, me.MessageCount);
 			}


### PR DESCRIPTION
 This means that people can reuse MessageElement and easily change the way it displays without starting from scratch (copying the code). Maybe this pattern could be useful for other elements too. This is not a breaking change - it maintains compatibility with existing code as the MessageElement siimply defaults to the existing MessageSummaryView. I'm happy to provide documentation and/or example code if this pull request is accepted.
