### PR TITLE
Adding a IB-compatible constructor for DialogViewController

### DIFF
--- a/MonoTouch.Dialog/DialogViewController.cs
+++ b/MonoTouch.Dialog/DialogViewController.cs
@@ -668,5 +668,9 @@ namespace MonoTouch.Dialog
 			this.pushing = pushing;
 			this.root = root;
 		}
+		public DialogViewController (IntPtr handle) : base(handle)
+		{
+			this.root = new RootElement ("");
+		}
 	}
 }


### PR DESCRIPTION
I might suggest to add a new constructor to DialogViewController class, that would allow to "reference" a dialog directly from Interface Builder while using storyboards, that instantiate new view controllers using the constructor with IntPtr parameter
