### PR TITLE
added external UISearchBar support

### DIFF
--- a/MonoTouch.Dialog/DialogViewController.cs
+++ b/MonoTouch.Dialog/DialogViewController.cs
@@ -487,15 +487,33 @@ namespace MonoTouch.Dialog
 				DismissModalViewControllerAnimated (animated);
 		}
 
+		public UISearchBar ExternalSearchBar 
+		{
+			get {
+				return _externalSearchBar;
+			}
+			set {
+				if (searchBar != null)
+					throw new ArgumentException("Internal searchBar already in use, assign before accessing tableView for first time.");
+				else if (_externalSearchBar != null)
+					throw new ArgumentException("External searchBar already in use, can only be assigned 1 time per intance");
+
+				_externalSearchBar = value;
+			}
+		}
+		private UISearchBar _externalSearchBar;
+
 		void SetupSearch ()
 		{
 			if (enableSearch){
-				searchBar = new UISearchBar (new RectangleF (0, 0, tableView.Bounds.Width, 44)) {
-					Delegate = new SearchDelegate (this)
-				};
+				searchBar = _externalSearchBar != null 
+					? _externalSearchBar : new UISearchBar (new RectangleF (0, 0, tableView.Bounds.Width, 44));
+				searchBar.Delegate = new SearchDelegate(this);
 				if (SearchPlaceholder != null)
 					searchBar.Placeholder = this.SearchPlaceholder;
-				tableView.TableHeaderView = searchBar;					
+
+				if (_externalSearchBar == null)
+					tableView.TableHeaderView = searchBar;					
 			} else {
 				// Does not work with current Monotouch, will work with 3.0
 				// tableView.TableHeaderView = null;

--- a/Sample/DemoSearch.cs
+++ b/Sample/DemoSearch.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using MonoTouch.UIKit;
+using MonoTouch.Dialog;
+using System.Collections.Generic;
+
+namespace Sample
+{
+	public partial class AppDelegate
+	{
+		public void DemoExternalSearchBar () 
+		{
+			UIViewController vcSearch = new UIViewController()
+			{
+				Title = "External Search Bar"
+			};
+
+			UISearchBar searchBar = new UISearchBar(RectangleF.FromLTRB(0, 0, navigation.View.Bounds.Width, 44)) {
+				Tag = 1
+			};
+
+			// add search bar
+			vcSearch.View.AddSubview(
+				searchBar
+			);
+
+			// add container for dvc tableView
+			vcSearch.View.AddSubview(
+				new UIView(RectangleF.FromLTRB(0, searchBar.Frame.Height, navigation.View.Bounds.Width, navigation.View.Frame.Height - searchBar.Frame.Height)) { 
+					Tag = 2
+				}
+			);
+
+			// create dvc and attach search bar
+			var dvc = new DialogViewController(new RootElement ("") {
+				from sh in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" 
+				    select new Section (sh + " - Section") {
+					   from filler in "12345" 
+						select (Element) new StringElement (sh + " - " + filler)
+				}
+			}, false) {
+				EnableSearch = true, 
+				ExternalSearchBar = searchBar
+			};
+
+			// add dvc to container view
+			vcSearch.View.ViewWithTag(2).AddSubview(dvc.TableView);
+
+			navigation.PushViewController (vcSearch, true);
+		}
+
+	}
+}
+

--- a/Sample/Main.cs
+++ b/Sample/Main.cs
@@ -61,6 +61,9 @@ namespace Sample
 				new Section ("Auto-mapped", footer){
 					new StringElement ("Reflection API", DemoReflectionApi)
 				},
+				new Section  ("Search") {
+					new StringElement("External Search Bar", DemoExternalSearchBar)
+				}
 			};
 			
 			//

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -91,6 +91,7 @@
     <Compile Include="DemoContainerStyle.cs" />
     <Compile Include="DemoIndex.cs" />
     <Compile Include="DemoEditingAdvanced.cs" />
+    <Compile Include="DemoSearch.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonoTouch.Dialog\MonoTouch.Dialog.csproj">


### PR DESCRIPTION
current search is simple to use but having the search bar scroll is not
always desired.  Allowing the caller to supply an external search bar
IMO gives better flexibility for DVC tableView containment.

Added a new "Search" section to the sample project, at the bottom of the view, to demo the usage.