### PR TITLE
Make sure new requests get a notification when the image is loaded. URI should be html encoded. Target filename is not updated when requests are popped from request queue.

### DIFF
--- a/MonoTouch.Dialog/Utilities/ImageLoader.cs
+++ b/MonoTouch.Dialog/Utilities/ImageLoader.cs
@@ -225,11 +225,11 @@ namespace MonoTouch.Dialog.Utilities
 			} 
 			if (uri.IsFile)
 				return null;
-			QueueRequest (uri, picfile, notify);
+			QueueRequest (uri, notify);
 			return null;
 		}
 		
-		static void QueueRequest (Uri uri, string target, IImageUpdated notify)
+		static void QueueRequest (Uri uri, IImageUpdated notify)
 		{
 			if (notify == null)
 				throw new ArgumentNullException ("notify");
@@ -249,7 +249,7 @@ namespace MonoTouch.Dialog.Utilities
 				else {
 					ThreadPool.QueueUserWorkItem (delegate { 
 							try {
-								StartPicDownload (uri, target); 
+								StartPicDownload (uri); 
 							} catch (Exception e){
 								Console.WriteLine (e);
 							}
@@ -258,11 +258,13 @@ namespace MonoTouch.Dialog.Utilities
 			}
 		}
 		
-		static bool Download (Uri uri, string target)
+		static bool Download (Uri uri)
 		{
 			try {
 				NSUrlResponse response;
 				NSError error;
+				
+				var target =  PicDir + md5 (uri.AbsoluteUri);
 				var req = new NSUrlRequest (new NSUrl (uri.AbsoluteUri.ToString ()), NSUrlRequestCachePolicy.UseProtocolCachePolicy, 120);
 				var data = NSUrlConnection.SendSynchronousRequest (req, out response, out error);
 				return data.Save (target, true, out error);
@@ -274,11 +276,11 @@ namespace MonoTouch.Dialog.Utilities
 		
 		static long picDownloaders;
 		
-		static void StartPicDownload (Uri uri, string target)
+		static void StartPicDownload (Uri uri)
 		{
 			Interlocked.Increment (ref picDownloaders);
 			try {
-				_StartPicDownload (uri, target);
+				_StartPicDownload (uri);
 			} catch (Exception e){
 				Console.Error.WriteLine ("CRITICAL: should have never happened {0}", e);
 			}
@@ -286,15 +288,15 @@ namespace MonoTouch.Dialog.Utilities
 			Interlocked.Decrement (ref picDownloaders);
 		}
 		
-		static void _StartPicDownload (Uri uri, string target)
+		static void _StartPicDownload (Uri uri)
 		{
 			do {
 				bool downloaded = false;
 				
 				//System.Threading.Thread.Sleep (5000);
-				downloaded = Download (uri, target);
-				if (!downloaded)
-					Console.WriteLine ("Error fetching picture for {0} to {1}", uri, target);
+				downloaded = Download (uri);
+				//if (!downloaded)
+				//	Console.WriteLine ("Error fetching picture for {0} to {1}", uri, target);
 				
 				// Cluster all updates together
 				bool doInvoke = false;


### PR DESCRIPTION
Make sure new requests get a notification when the image is loaded. URI should be html encoded. Target filename is not updated when requests are popped from request queue.
