### PR TITLE
Fixed EntryElement.Changed so that it fires when the user changes the text

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1547,7 +1547,7 @@ namespace MonoTouch.Dialog
 				
 				entry = CreateTextField (new RectangleF (size.Width, yOffset, width, size.Height));
 				
-				entry.ValueChanged += delegate {
+				entry.EditingChanged += delegate {
 					FetchValue ();
 				};
 				entry.Ended += delegate {					


### PR DESCRIPTION
EntryElement.Changed was not getting fired when a user changes the text
(but remains in the UITextField).

ValueChanged is not fired when the user changes the text in a
UITextField - needed to be UITextField.EditingChanged.
