### PR TITLE
Fixes #91 EntryAlignment bug on iPad

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1509,7 +1509,7 @@ namespace MonoTouch.Dialog
 		protected virtual UITextField CreateTextField (RectangleF frame)
 		{
 			return new UITextField (frame) {
-				AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleLeftMargin,
+				AutoresizingMask = UIViewAutoresizing.None,
 				Placeholder = placeholder ?? "",
 				SecureTextEntry = isPassword,
 				Text = Value ?? "",
@@ -1545,7 +1545,7 @@ namespace MonoTouch.Dialog
 					width -= 10;
 				}
 				
-				entry = CreateTextField (new RectangleF (size.Width, yOffset, width, size.Height));
+				entry = CreateTextField (new RectangleF (cell.ContentView.Bounds.Width, yOffset, width, size.Height));
 				
 				entry.ValueChanged += delegate {
 					FetchValue ();


### PR DESCRIPTION
This commit fixes #91 EntryAlignment bug on iPad by restricting resizing and positioning the cell in the center
