### PR TITLE
Fixes #91 EntryAlignment bug on iPad

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1533,6 +1533,10 @@ namespace MonoTouch.Dialog
 			if (cell == null){
 				cell = new UITableViewCell (UITableViewCellStyle.Default, CellKey);
 				cell.SelectionStyle = UITableViewCellSelectionStyle.None;
+
+				var offset = (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone) ? 20 : 90;
+				cell.Frame = new RectangleF(cell.Frame.X, cell.Frame.Y, tv.Frame.Width-offset, cell.Frame.Height);
+
 			} else 
 				RemoveTag (cell, 1);
 			


### PR DESCRIPTION
This finally fixes #91 EntryAlignment bug on iPad. It turns out that on new cell creation, the width value appears to be hardcoded at 320. The correct value is only recalculated on cell reuse. This causes the initial value for cell.ContentView.Bounds to return the wrong value. I wish there was a more elegant solution, but this does the trick for now.
