### PR TITLE
Correct displaying of time in update label.

### DIFF
--- a/MonoTouch.Dialog/Utilities/Controls.cs
+++ b/MonoTouch.Dialog/Utilities/Controls.cs
@@ -176,7 +176,7 @@ namespace MonoTouch.Dialog
 				if (value == DateTime.MinValue){
 					LastUpdateLabel.Text = "Last Updated: never".GetText ();
 				} else 
-					LastUpdateLabel.Text = String.Format ("Last Updated: {0:g}".GetText (), value);
+					LastUpdateLabel.Text = String.Format ("Last Updated: {0:d} {1}".GetText (), value, value.ToString("h:mm tt"));
 			}
 		}
 		


### PR DESCRIPTION
Changed the time for RefreshTableHeaderView. In Australia in the
simulator it would display the time with a trailing "AM" or "PM", but
on the device it would only display "A" or "P". This fixes that and
preserves default date format.
