### PR TITLE
Added optional explicit summary to RootElement.

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -2388,6 +2388,7 @@ namespace MonoTouch.Dialog
 		static NSString rkey1 = new NSString ("RootElement1");
 		static NSString rkey2 = new NSString ("RootElement2");
 		int summarySection, summaryElement;
+		string explicitSummary;
 		internal Group group;
 		public bool UnevenRows;
 		public Func<RootElement, UIViewController> createOnSelected;
@@ -2406,6 +2407,22 @@ namespace MonoTouch.Dialog
 		/// </param>
 		public RootElement (string caption) : base (caption)
 		{
+			summarySection = -1;
+			Sections = new List<Section> ();
+		}
+
+		/// <summary>
+		///  Initializes a RootSection with a caption and a summary
+		/// </summary>
+		/// <param name="caption">
+		///  The caption to render.
+		/// </param>
+		/// <param name="summary">
+		///  The summary to render.
+		/// </param>
+		public RootElement (string caption, string summary) : base (caption)
+		{
+			explicitSummary = summary;
 			summarySection = -1;
 			Sections = new List<Section> ();
 		}
@@ -2732,7 +2749,7 @@ namespace MonoTouch.Dialog
 			NSString key = summarySection == -1 ? rkey1 : rkey2;
 			var cell = tv.DequeueReusableCell (key);
 			if (cell == null){
-				var style = summarySection == -1 ? UITableViewCellStyle.Default : UITableViewCellStyle.Value1;
+				var style = summarySection == -1 && explicitSummary == null ? UITableViewCellStyle.Default : UITableViewCellStyle.Value1;
 				
 				cell = new UITableViewCell (style, key);
 				cell.SelectionStyle = UITableViewCellSelectionStyle.Blue;
@@ -2776,6 +2793,9 @@ namespace MonoTouch.Dialog
 					}
 				}
 				cell.DetailTextLabel.Text = count.ToString ();
+			} else if (explicitSummary != null) {
+				if (cell.DetailTextLabel != null)
+					cell.DetailTextLabel.Text = explicitSummary;
 			} else if (summarySection != -1 && summarySection < Sections.Count){
 					var s = Sections [summarySection];
 					if (summaryElement < s.Elements.Count && cell.DetailTextLabel != null)

--- a/Sample/DemoElementApi.cs
+++ b/Sample/DemoElementApi.cs
@@ -52,7 +52,12 @@ namespace Sample
 					new TimeElement ("Select Time", DateTime.Now),
 				},
 				new Section () {
-					CreateGeneralSection (),		
+					CreateGeneralSection (),
+					new RootElement ("RootElement", "Explicit Summary") {
+						new Section ("About this test"){
+							new MultilineElement ("A root element with an explicit summary")
+						}
+					}
 					//new RootElement ("Mail, Contacts, Calendars"),
 					//new RootElement ("Phone"),
 					//new RootElement ("Safari"),


### PR DESCRIPTION
An explicit sumary may be useful for an application that may show a
derivative value (determined by a business rule) on the root element
summary as opposed to a direct binding to a child element value.

In my case I want to show an appointment by

[CustomerName           StartTime - ToTime  >]

which requires the summary value be explicitly given to the root element.
