### PR TITLE
Fixed some compile warnings

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -449,13 +449,13 @@ namespace MonoTouch.Dialog
 		public float Value;
 		public float MinValue, MaxValue;
 		static NSString skey = new NSString ("FloatElement");
-		UIImage Left, Right;
+		//UIImage Left, Right;
 		UISlider slider;
 		
 		public FloatElement (UIImage left, UIImage right, float value) : base (null)
 		{
-			Left = left;
-			Right = right;
+			//Left = left;
+			//Right = right;
 			MinValue = 0;
 			MaxValue = 1;
 			Value = value;
@@ -1147,7 +1147,7 @@ namespace MonoTouch.Dialog
 		{
 			using (var cs = CGColorSpace.CreateDeviceRGB ()){
 				using (var bit = new CGBitmapContext (IntPtr.Zero, dimx, dimy, 8, 0, cs, CGImageAlphaInfo.PremultipliedFirst)){
-					bit.SetRGBStrokeColor (1, 0, 0, 0.5f);
+					bit.SetStrokeColor (1, 0, 0, 0.5f);
 					bit.FillRect (new RectangleF (0, 0, dimx, dimy));
 					
 					return UIImage.FromImage (bit.ToImage ());
@@ -1287,8 +1287,8 @@ namespace MonoTouch.Dialog
 				if (cell == null)
 					useRect = rect;
 				else
-					rect = cell.Frame;
-				popover.PresentFromRect (rect, dvc.View, UIPopoverArrowDirection.Any, true);
+					useRect = cell.Frame;
+				popover.PresentFromRect (useRect, dvc.View, UIPopoverArrowDirection.Any, true);
 				break;
 				
 			default:

--- a/MonoTouch.Dialog/Elements/ElementBadge.cs
+++ b/MonoTouch.Dialog/Elements/ElementBadge.cs
@@ -119,7 +119,7 @@ namespace MonoTouch.Dialog
 					//context.ScaleCTM (0.5f, -1);
 					context.TranslateCTM (0, 0);
 					context.DrawImage (new RectangleF (0, 0, 57, 57), template.CGImage);
-					context.SetRGBFillColor (1, 1, 1, 1);
+					context.SetFillColor (1, 1, 1, 1);
 					
 					context.SelectFont ("Helvetica", 10f, CGTextEncoding.MacRoman);
 					
@@ -139,7 +139,7 @@ namespace MonoTouch.Dialog
 					context.ShowText (bigText);
 					width = context.TextPosition.X - start;
 					
-					context.SetRGBFillColor (0, 0, 0, 1);
+					context.SetFillColor (0, 0, 0, 1);
 					context.SetTextDrawingMode (CGTextDrawingMode.Fill);
 					context.ShowTextAtPoint ((57-width)/2, 9, bigText);
 					

--- a/MonoTouch.Dialog/Utilities/ImageLoader.cs
+++ b/MonoTouch.Dialog/Utilities/ImageLoader.cs
@@ -216,7 +216,7 @@ namespace MonoTouch.Dialog.Utilities
 
 			string picfile = uri.IsFile ? uri.LocalPath : PicDir + md5 (uri.AbsoluteUri);
 			if (File.Exists (picfile)){
-				ret = UIImage.FromFileUncached (picfile);
+				ret = UIImage.FromFile (picfile);
 				if (ret != null){
 					lock (cache)
 						cache [uri] = ret;


### PR DESCRIPTION
Fixes some compile warnings related to old deprecated MonoTouch methods and fixes ImageElement to not clobber it's global "rect" variable (which should probably be marked as readonly to catch bugs like this in the future).
