### PR TITLE
Fixed EntryElements to use a separate key for password entries

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1518,12 +1518,13 @@ namespace MonoTouch.Dialog
 				ClearButtonMode = ClearButtonMode
 			};
 		}
-		
-		static NSString cellkey = new NSString ("EntryElement");
+
+		static readonly NSString passwordKey = new NSString ("EntryElement+Password");
+		static readonly NSString cellkey = new NSString ("EntryElement");
 		
 		protected override NSString CellKey {
 			get {
-				return cellkey;
+				return isPassword ? passwordKey : cellkey;
 			}
 		}
 		


### PR DESCRIPTION
Fixes http://stackoverflow.com/questions/13706729/why-are-some-of-these-monotouch-dialog-cells-appearing-empty
