### PR TITLE
[Fix] Element.IndexPath is null after search was activated.

### DIFF
--- a/MonoTouch.Dialog/DialogViewController.cs
+++ b/MonoTouch.Dialog/DialogViewController.cs
@@ -199,6 +199,12 @@ namespace MonoTouch.Dialog
 				return;
 			
 			Root.Sections = new List<Section> (originalSections);
+
+			// restore element's parents
+			foreach (var section in Root.Sections)
+				foreach (var element in section.Elements)
+					element.Parent = section;
+
 			originalSections = null;
 			originalElements = null;
 			searchBar.ResignFirstResponder ();
@@ -243,7 +249,11 @@ namespace MonoTouch.Dialog
 			}
 			
 			Root.Sections = newSections;
-			
+
+			// apply parent to new sections
+			foreach (var section in newSections)
+				section.Parent = Root;
+
 			ReloadData ();
 		}
 		

--- a/Sample/DemoColoredList.cs
+++ b/Sample/DemoColoredList.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+using MonoTouch.Dialog;
+using MonoTouch.UIKit;
+
+namespace Sample
+{
+	class ColoredViewController : DialogViewController {
+		public ColoredViewController (RootElement root, bool pushing) : base (root, pushing)
+		{
+			Style = UITableViewStyle.Plain;
+			EnableSearch = true;
+			SearchPlaceholder = "Find item";
+		}
+	}
+
+	public partial class AppDelegate
+	{
+		class CustomElement : StringElement
+		{
+			static UIColor EvenColor = UIColor.White;
+			static UIColor UnevenColor = UIColor.FromRGB(245, 245, 245);
+
+			public CustomElement(string caption) : base(caption)
+			{}
+
+			public override UITableViewCell GetCell (UITableView tv)
+			{
+				var cell = base.GetCell (tv);
+				var color = IndexPath.Row % 2 == 0 ? EvenColor : UnevenColor;
+				cell.TextLabel.BackgroundColor = color;
+				cell.ContentView.BackgroundColor = color;
+				return cell;
+			}
+		}
+
+		public void DemoColoredList ()
+		{
+			var root = new RootElement ("Colored List Demo") {
+				from sh in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" 
+					select new Section (sh + " - Section") {
+						from filler in "12345" 
+							select (Element) new CustomElement (sh + " - " + filler)
+					}
+			};
+			var dvc = new ColoredViewController (root, true);
+			navigation.PushViewController (dvc, true);
+		}
+	}
+}
+

--- a/Sample/Main.cs
+++ b/Sample/Main.cs
@@ -52,6 +52,7 @@ namespace Sample
 					new StringElement ("Headers and Footers", DemoHeadersFooters),
 					new StringElement ("Root Style", DemoContainerStyle),
 					new StringElement ("Index sample", DemoIndex),
+					new StringElement ("Colored list", DemoColoredList),
 				},
 				new Section ("Json") {
 					(sampleJson = JsonElement.FromFile ("sample.json")),

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -12,23 +12,23 @@
     <AssemblyName>Sample</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
     <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchLink>None</MtouchLink>
-    <MtouchDebug>true</MtouchDebug>
+    <MtouchDebug>True</MtouchDebug>
     <MtouchExtraArgs>--nostrip</MtouchExtraArgs>
     <MtouchI18n />
     <MtouchUseArmv7>false</MtouchUseArmv7>
-    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseSGen>True</MtouchUseSGen>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <OutputPath>bin\iPhoneSimulator\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -36,27 +36,27 @@
     <MtouchI18n />
     <MtouchSdkVersion>4.3</MtouchSdkVersion>
     <MtouchUseArmv7>false</MtouchUseArmv7>
-    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseSGen>True</MtouchUseSGen>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\Debug</OutputPath>
     <DefineConstants>DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchDebug>true</MtouchDebug>
+    <MtouchDebug>True</MtouchDebug>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchLink>None</MtouchLink>
     <MtouchUseArmv7>false</MtouchUseArmv7>
     <IpaPackageName />
     <MtouchI18n />
-    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseSGen>True</MtouchUseSGen>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>False</Optimize>
     <OutputPath>bin\iPhone\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -65,7 +65,7 @@
     <MtouchI18n />
     <MtouchSdkVersion>3.0</MtouchSdkVersion>
     <MtouchUseArmv7>false</MtouchUseArmv7>
-    <MtouchUseSGen>true</MtouchUseSGen>
+    <MtouchUseSGen>True</MtouchUseSGen>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -91,6 +91,7 @@
     <Compile Include="DemoContainerStyle.cs" />
     <Compile Include="DemoIndex.cs" />
     <Compile Include="DemoEditingAdvanced.cs" />
+    <Compile Include="DemoColoredList.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MonoTouch.Dialog\MonoTouch.Dialog.csproj">


### PR DESCRIPTION
Fixed an issue when Element.IndexPath is null after search was activated.

DemoColoredList added to test the issue:
- CustomElement uses IndexPath to change background color.

As an option: move parent reassignment logic from DialogViewController to Section.
