### PR TITLE
Section.GetImmediateRootElement() always returns null

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -153,6 +153,8 @@ namespace MonoTouch.Dialog
 		public RootElement GetImmediateRootElement ()
 		{
 				var section = Parent as Section;
+                if (section == null)
+                    section = this as Section;
 				if (section == null)
 					return null;
 				return section.Parent as RootElement;


### PR DESCRIPTION
The previous implementation of `Element.GetImmediateRootElement()` always assumes the element's parent is a section. This means when the element is actually a section it always returns null. This has flow on effects for methods that rely on it such as `GetContainerTableView()` always returning null for Sections.

I could have made the `Element.GetImmediateRootElement` virtual and overrode it in Section, but that then opens it up for extension in all derived Elements, something I thought was wrong for this method. Instead I do the somewhat weird `section = this as Section`.

No idea what happened with the indent formatting? The files locally are showing the same tab alignment, but now the github 'Files Changed' formatting is showing my additions indented more? Sorry about that.
