### PR TITLE
Fixed a bug where DateTimeElements don't show any selection animation.

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1725,6 +1725,7 @@ namespace MonoTouch.Dialog
 			Value = FormatDate (DateValue);
 			var cell = base.GetCell (tv);
 			cell.Accessory = UITableViewCellAccessory.DisclosureIndicator;
+            cell.SelectionStyle = UITableViewCellSelectionStyle.Blue;
 			return cell;
 		}
  


### PR DESCRIPTION
... due to deriving from StringElement, and StringElements only enabling selection if the Tapped event is subscribed to. DateTime elements overload the OnSelected method and so never have a Tapped subscription. Fixed by forcing to always use a selection style.
