### PR TITLE
EntryElement UITextField position miscalculated

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1431,7 +1431,6 @@ namespace MonoTouch.Dialog
 		bool isPassword, becomeResponder;
 		UITextField entry;
 		string placeholder;
-		static UIFont font = UIFont.BoldSystemFontOfSize (17);
 
 		public event EventHandler Changed;
 		public event Func<bool> ShouldReturn;
@@ -1493,6 +1492,7 @@ namespace MonoTouch.Dialog
 			
 			// If all EntryElements have a null Caption, align UITextField with the Caption
 			// offset of normal cells (at 10px).
+			UIFont font = UIFont.BoldSystemFontOfSize (17);
 			SizeF max = new SizeF (-15, tv.StringSize ("M", font).Height);
 			foreach (var e in s.Elements){
 				var ee = e as EntryElement;

--- a/Sample/DemoDynamic.cs
+++ b/Sample/DemoDynamic.cs
@@ -83,7 +83,7 @@ namespace Sample
 						new StringElement (texts [i])
 					}
 				};
-				section.Add (line);
+				section.Add ((Element) line);
 			}
 			
 			return root;

--- a/Sample/DemoElementApi.cs
+++ b/Sample/DemoElementApi.cs
@@ -23,21 +23,21 @@ namespace Sample
 			return new RootElement ("Settings") {
 				new Section (){
 					new BooleanElement ("Airplane Mode", false),
-					new RootElement ("Notifications", 0, 0) {
+					(Element) new RootElement ("Notifications", 0, 0) {
 						new Section (null, "Turn off Notifications to disable Sounds\n" +
 							     "Alerts and Home Screen Badges for the\napplications below."){
 							new BooleanElement ("Notifications", false)
 						}
 					}},
 				new Section (){
-					CreateSoundSection (),
-					new RootElement ("Brightness"){
+					(Element) CreateSoundSection (),
+					(Element) new RootElement ("Brightness"){
 						new Section (){
 							new FloatElement (null, null, 0.5f),
 							new BooleanElement ("Auto-brightness", false),
 						}
 					},
-					new RootElement ("Wallpaper"){
+					(Element) new RootElement ("Wallpaper"){
 						new Section (){
 							new ImageElement (null),
 							new ImageElement (null),
@@ -52,7 +52,7 @@ namespace Sample
 					new TimeElement ("Select Time", DateTime.Now),
 				},
 				new Section () {
-					CreateGeneralSection (),		
+					(Element) CreateGeneralSection (),		
 					//new RootElement ("Mail, Contacts, Calendars"),
 					//new RootElement ("Phone"),
 					//new RootElement ("Safari"),
@@ -77,7 +77,7 @@ namespace Sample
 				new Section ("Ring") {
 					new BooleanElement ("Vibrate", true),
 					new FloatElement (null, null, 0.8f),
-					new RootElement ("Ringtone", new RadioGroup (0)){
+					(Element) new RootElement ("Ringtone", new RadioGroup (0)){
 						new Section ("Custom"){
 							new RadioElement ("Circus Music"),
 							new RadioElement ("True Blood"),
@@ -87,7 +87,7 @@ namespace Sample
 								select (Element) new RadioElement (n)
 						}
 					},
-					new RootElement ("New Text Message", new RadioGroup (3)){
+					(Element) new RootElement ("New Text Message", new RadioGroup (3)){
 						new Section (){
 							from n in "None,Tri-tone,Chime,Glass,Horn,Bell,Eletronic".Split (',')
 								select (Element) new RadioElement (n)
@@ -107,9 +107,9 @@ namespace Sample
 		{
 			return new RootElement ("General") {
 				new Section (){
-					new RootElement ("About"){
+					(Element) new RootElement ("About"){
 						new Section ("My Phone") {
-							new RootElement ("Network", new RadioGroup (null, 0)) {
+							(Element) new RootElement ("Network", new RadioGroup (null, 0)) {
 								new Section (){
 									new RadioElement ("My First Network"),
 									new RadioElement ("Second Network"),
@@ -132,7 +132,7 @@ namespace Sample
 							new HtmlElement ("Monologue", "http://www.go-mono.com/monologue"),
 						}
 					},
-					new RootElement ("Usage"){
+					(Element) new RootElement ("Usage"){
 						new Section ("Time since last full charge"){
 							new StringElement ("Usage", "0 minutes"),
 							new StringElement ("Standby", "0 minutes"),
@@ -153,7 +153,7 @@ namespace Sample
 					}
 				},
 				new Section (){
-					new RootElement ("Network"){
+					(Element) new RootElement ("Network"){
 						new Section (null, "Using 3G loads data faster\nand burns the battery"){
 							new BooleanElement ("Enable 3G", true)
 						},
@@ -161,7 +161,7 @@ namespace Sample
 							new BooleanElement ("Data Roaming", false),
 						},
 						new Section (){
-							new RootElement ("VPN", 0, 0){
+							(Element) new RootElement ("VPN", 0, 0){
 								new Section (){
 									new BooleanElement ("VPN", false),
 								},
@@ -171,7 +171,7 @@ namespace Sample
 							}
 						}
 					},
-					new RootElement ("Bluetooth", 0, 0){
+					(Element) new RootElement ("Bluetooth", 0, 0){
 						new Section (){
 							new BooleanElement ("Bluetooth", false)
 						}
@@ -179,7 +179,7 @@ namespace Sample
 					new BooleanElement ("Location Services", true),
 				},
 				new Section (){
-					new RootElement ("Auto-Lock", new RadioGroup (0)){
+					(Element) new RootElement ("Auto-Lock", new RadioGroup (0)){
 						new Section (){
 							new RadioElement ("1 Minute"),
 							new RadioElement ("2 Minutes"),
@@ -194,7 +194,7 @@ namespace Sample
 					new BooleanElement ("Restrictions", false),
 				},
 				new Section () {
-					new RootElement ("Home", new RadioGroup (2)){
+					(Element) new RootElement ("Home", new RadioGroup (2)){
 						new Section ("Double-click the Home Button for:"){
 							new RadioElement ("Home"),
 							new RadioElement ("Search"),
@@ -208,7 +208,7 @@ namespace Sample
 						// Missing feature: sortable list of data
 						// SearchResults
 					},
-					new RootElement ("Date & Time"){
+					(Element) new RootElement ("Date & Time"){
 						new Section (){
 							new BooleanElement ("24-Hour Time", false),
 						},
@@ -218,7 +218,7 @@ namespace Sample
 							// SetTime: Can be imeplemeneted with String + Tapped Event
 						}
 					},
-					new RootElement ("Keyboard"){
+					(Element) new RootElement ("Keyboard"){
 						new Section (null, "Double tapping the space bar will\n" +
 							"insert a period followed by a space"){
 							new BooleanElement ("Auto-Correction", true),
@@ -227,7 +227,7 @@ namespace Sample
 							new BooleanElement ("\".\" Shortcut", true),
 						},
 						new Section (){
-							new RootElement ("International Keyboards", new Group ("kbd")){
+							(Element) new RootElement ("International Keyboards", new Group ("kbd")){
 								new Section ("Using Checkboxes"){
 									new CheckboxElement ("English", true, "kbd"),
 									new CheckboxElement ("Spanish", false, "kbd"),

--- a/Sample/DemoHeadersFooters.cs
+++ b/Sample/DemoHeadersFooters.cs
@@ -24,7 +24,7 @@ namespace Sample
 				}
 			};
 
-			section.Add (new RootElement ("Desert", new RadioGroup ("desert", 0)){
+			section.Add ((Element) new RootElement ("Desert", new RadioGroup ("desert", 0)){
 				new Section () {
 					new RadioElement ("Ice Cream", "desert"),
 					new RadioElement ("Milkshake", "desert"),
@@ -34,7 +34,7 @@ namespace Sample
 			
 			var root = new RootElement ("Headers and Footers") {
 				section,
-				new Section () { linqRoot }
+				new Section () { (Element) linqRoot }
 			};
 			var dvc = new DialogViewController (root, true);
 			navigation.PushViewController (dvc, true);

--- a/Sample/Main.cs
+++ b/Sample/Main.cs
@@ -54,9 +54,9 @@ namespace Sample
 					new StringElement ("Index sample", DemoIndex),
 				},
 				new Section ("Json") {
-					(sampleJson = JsonElement.FromFile ("sample.json")),
+					(Element) (sampleJson = JsonElement.FromFile ("sample.json")),
 					// Notice what happens when I close the paranthesis at the end, in the next line:
-					new JsonElement ("Load from URL", "file://" + Path.GetFullPath ("sample.json"))
+					(Element) new JsonElement ("Load from URL", "file://" + Path.GetFullPath ("sample.json"))
 				},
 				new Section ("Auto-mapped", footer){
 					new StringElement ("Reflection API", DemoReflectionApi)


### PR DESCRIPTION
When testing an app that uses an EntryElement on an Ad-Hoc configuration (couldn't reproduce it in Debug), after a while (usually the 2nd or 3rd time loading a dialog) the static UIFont that is used to calculate the EntryAligment returns a font of size 0. So it messes up all the calculations for the ComputeEntryPosition method.

Using a local UIFont var fixes the problem.

I think this could be a problem of the mono compiler, but at least this patch fixes the issue for MT.D. 

Hope it helps!

PS. system info below

Xamarin Studio
Version 4.0.3 (build 13)
Installation UUID: 675af92b-4382-4a2c-aeb5-2718b3d00757
Runtime:
    Mono 3.0.7 (master/514fcd7)
    GTK 2.24.16
    GTK# (2.12.0.0)
    Package version: 300070000

Apple Developer Tools
Xcode 4.6.1 (2067)
Build 4H512

Xamarin.iOS
Version: 6.3.2.0 (Indie Edition)
Hash: 56e611b
Branch: 
Build date: 2013-25-03 21:37:44-0400
