### PR TITLE
Fixes the size of the TextLabel caption in EntryElement

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1537,6 +1537,7 @@ namespace MonoTouch.Dialog
 			if (cell == null) {
 				cell = new UITableViewCell (UITableViewCellStyle.Default, CellKey);
 				cell.SelectionStyle = UITableViewCellSelectionStyle.None;
+				cell.TextLabel.Font = font;
 
 			} 
 			cell.TextLabel.Text = Caption;


### PR DESCRIPTION
I found that a recent commit had made EntryElement's caption font too large. This commit explicitly sets the font of the TextLabel.
