### PR TITLE
Allow customisation of each cell in a Section before its used 

### DIFF
--- a/MonoTouch.Dialog/DialogViewController.cs
+++ b/MonoTouch.Dialog/DialogViewController.cs
@@ -338,7 +338,7 @@ namespace MonoTouch.Dialog
 				var section = Root.Sections [indexPath.Section];
 				var element = section.Elements [indexPath.Row];
 				
-				return element.GetCell (tableView);
+				return section.CustomizeCell(element.GetCell (tableView), indexPath);
 			}
 			
 			public override void WillDisplay (UITableView tableView, UITableViewCell cell, NSIndexPath indexPath)

--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -2343,6 +2343,12 @@ namespace MonoTouch.Dialog
 			
 			return cell;
 		}
+
+		public virtual UITableViewCell CustomizeCell(UITableViewCell source, NSIndexPath indexPath)
+		{
+			return source;
+		}
+
 	}
 	
 	/// <summary>


### PR DESCRIPTION
this came out of my Evolve talk.

Allows a Section to customise its elements before they are used - so you can change the background of the element correctly without changing how the element works.

Another way could be to make the Section implement an interface like IElementResizing, not sure if an otherwise blank method call is quicker/better than a "if (x is ISectionCustomisation)" type call. Happy to rework if it is.

Should have submitted this a year ago. :(
