### PR TITLE
StringElement bugfix (Horizontal text alignment)

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1,4 +1,3 @@
-
 //
 // Elements.cs: defines the various components of our view
 //
@@ -667,7 +666,7 @@ namespace MonoTouch.Dialog
 		{
 			var cell = tv.DequeueReusableCell (Value == null ? skey : skeyvalue);
 			if (cell == null){
-				cell = new UITableViewCell (Value == null ? UITableViewCellStyle.Default : UITableViewCellStyle.Value1, skey);
+				cell = new UITableViewCell (Value == null ? UITableViewCellStyle.Default : UITableViewCellStyle.Value1, Value == null ? skey : skeyvalue);
 				cell.SelectionStyle = (Tapped != null) ? UITableViewCellSelectionStyle.Blue : UITableViewCellSelectionStyle.None;
 			}
 			cell.Accessory = UITableViewCellAccessory.None;


### PR DESCRIPTION
Bug description:
Multiple StringElements in the same View (some with values set, some without values/only with caption)
Set the alignment of the string element without values to "UITextAlignment.Center"
The alignment of the center elements switches randomly between "left" and "center" at each "ReloadData".

=> reason: if a value is set for a string element, the reuse identifier has been wrong (differed from the reuse identifier which is used to find the element)
