### PR TITLE
Fix indexed list bug that crashed the app when performing a search

### DIFF
--- a/Sample/DemoIndex.cs
+++ b/Sample/DemoIndex.cs
@@ -33,7 +33,11 @@ namespace Sample
 		
 		string [] GetSectionTitles ()
 		{
-			return (from section in Root select section.Caption.Substring(0,1)).ToArray ();
+			return (
+				from section in Root
+				where !String.IsNullOrEmpty(section.Caption)
+				select section.Caption.Substring(0,1)
+			).ToArray ();
 		}
 		
 		class IndexedSource : Source {


### PR DESCRIPTION
This bug was has been reported already:
https://bugzilla.xamarin.com/show_bug.cgi?id=16120#c2
https://github.com/migueldeicaza/MonoTouch.Dialog/issues/139
