### PR TITLE
Allow for easier subclassing of radio-elements that requires the same accessory

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1080,7 +1080,7 @@ namespace MonoTouch.Dialog
 
 		public virtual UITableViewCellAccessory Accessory {
 			get {
-				return Selected ? UITableViewCellAccessory.Checkmark : UITableViewCellAccessory.None;
+				return IsSelected ? UITableViewCellAccessory.Checkmark : UITableViewCellAccessory.None;
 			}
 		}
 

--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1060,16 +1060,28 @@ namespace MonoTouch.Dialog
 
 		public override UITableViewCell GetCell (UITableView tv)
 		{
-			var cell = base.GetCell (tv);			
-			var root = (RootElement) Parent.Parent;
-			
-			if (!(root.group is RadioGroup))
-				throw new Exception ("The RootElement's Group is null or is not a RadioGroup");
-			
-			bool selected = RadioIdx == ((RadioGroup)(root.group)).Selected;
-			cell.Accessory = selected ? UITableViewCellAccessory.Checkmark : UITableViewCellAccessory.None;
+			var cell = base.GetCell (tv);	
+					
+			cell.Accessory = Accessory;
 
 			return cell;
+		}
+
+		public bool IsSelected {
+			get {
+				var root = (RootElement)Parent.Parent;
+
+				if (!(root.group is RadioGroup))
+					throw new Exception ("The RootElement's Group is null or is not a RadioGroup");
+
+				return RadioIdx == ((RadioGroup)(root.group)).Selected;
+			}
+		}
+
+		public virtual UITableViewCellAccessory Accessory {
+			get {
+				return Selected ? UITableViewCellAccessory.Checkmark : UITableViewCellAccessory.None;
+			}
 		}
 
 		public override void Selected (DialogViewController dvc, UITableView tableView, NSIndexPath indexPath)


### PR DESCRIPTION
I recently needed to subclass the `RadioElement` class to add an image to the left of the text. There were probably other ways I could have done this, but I created a subclass of `UITableViewCell` meaning I couldn't simply do `base.GetCell()`, so I had to recreate the code that does the adding of the cell accessory. This turned out to be quite painful, because a lot of the needed objects are marked as internal, thus I edited the `RadioElement` class to easily allow for such scenarios.
