### PR TITLE
[Fix] EntryElement: TextField misalignment on cell reuse

### DIFF
--- a/MonoTouch.Dialog/Elements.cs
+++ b/MonoTouch.Dialog/Elements.cs
@@ -1812,8 +1812,7 @@ namespace MonoTouch.Dialog
 					tv.ScrollToRow (IndexPath, UITableViewScrollPosition.Middle, true);
 				};
 				cell.ContentView.AddSubview (entry);
-			} else
-				entry.Frame = entryFrame;
+			}
 
 			if (becomeResponder){
 				entry.BecomeFirstResponder ();


### PR DESCRIPTION
## How to reproduce the issue
1. Load the DemoRelectionApi Sample

![screen shot 2016-10-01 at 9 00 02 pm](https://cloud.githubusercontent.com/assets/2255137/19018118/38fc37cc-8888-11e6-8bf4-3a765384b530.png)

> I have added a grey background to the textfield to highlight the issue
1. Rotate or navigate in to TimeSettings and come back

![screen shot 2016-10-01 at 9 00 31 pm](https://cloud.githubusercontent.com/assets/2255137/19018126/6febe412-8888-11e6-8bd1-0003465db548.png)
## Solution

Don't re assign the computed frame on cell reuse. This fixes the entry element misalignment.
