### PR TITLE
[MT.D] Fixes tvOS library and sample build

### DIFF
--- a/MonoTouch.Dialog/DialogViewController.cs
+++ b/MonoTouch.Dialog/DialogViewController.cs
@@ -126,7 +126,9 @@ namespace MonoTouch.Dialog
 
 			reloading = false;
 
+#if !__TVOS__
 			RefreshControl.EndRefreshing ();
+#endif
 		}
 		
 		/// <summary>

--- a/MonoTouch.Dialog/MonoTouch.Dialog-tvOS.csproj
+++ b/MonoTouch.Dialog/MonoTouch.Dialog-tvOS.csproj
@@ -70,11 +70,6 @@
   <ItemGroup>
     <Folder Include="Images\" />
   </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Images\arrow.png">
-      <LogicalName>arrow.png</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
   <Import Project="MonoTouch.Dialog.projitems" Label="Shared" Condition="Exists('MonoTouch.Dialog.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\TVOS\Xamarin.TVOS.CSharp.targets" />
 </Project>

--- a/Sample/Info-tvOS.plist
+++ b/Sample/Info-tvOS.plist
@@ -9,5 +9,13 @@
 		<integer>1</integer>
 		<integer>2</integer>
 	</array>
+	<key>CFBundleName</key>
+	<string>SampleTV</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.sample.monotouchdialogtv</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
The tvOS build of both the sample and library were broken.

* The resource `arrow.png` is no longer used and was removed by  https://github.com/migueldeicaza/MonoTouch.Dialog/commit/338abfe687d2461536272017ca439b443db5c2ad but only for the iOS project.
* Adds some boilerplate information to `Sample/Info-tvOS.plist` so the sample runs out of the box.
* `UIRefreshControl` is not available in tvOS.