### PR TITLE
Use [Weak] instead to avoid a breaking change in our frozen binary

### DIFF
--- a/MonoTouch.Dialog/DialogViewController.cs
+++ b/MonoTouch.Dialog/DialogViewController.cs
@@ -329,14 +329,13 @@ namespace MonoTouch.Dialog
 		
 		public class Source : UITableViewSource {
 			const float yboundary = 65;
-			WeakReference<DialogViewController> container;
-			protected DialogViewController Container => container.TryGetTarget (out var result) ? result : null;
+			[Weak] protected DialogViewController Container;
 			protected RootElement Root;
 			bool checkForRefresh;
 			
 			public Source (DialogViewController container)
 			{
-				this.container = new WeakReference<DialogViewController> (container);
+				Container = container;
 				Root = container.root;
 			}
 			


### PR DESCRIPTION
Fixes breaking change in our current [frozen binary](0)

```
    MonoTouch.Dialog-1.dll

    Show non-breaking changes
    Namespace MonoTouch.Dialog

    Type Changed: MonoTouch.Dialog.DialogViewController

    Type Changed: MonoTouch.Dialog.DialogViewController.Source

    Removed field:

            protected DialogViewController Container;
```

[0]: https://github.com/xamarin/macios-binaries/tree/master/MonoTouch.Dialog-Unified