### PR TITLE
[dotnet] Shared project files don't need the DefaultTargets/ToolsVersion/xmlns attributes.

### DIFF
--- a/MonoTouch.Dialog/dotnet/shared.csproj
+++ b/MonoTouch.Dialog/dotnet/shared.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>MonoTouch.Dialog</RootNamespace>


### PR DESCRIPTION
This makes it easier for xharness to process this shared file, because the
xmlns attribute complicates matters.