### PR TITLE
[MonoTouch.Dialog] Use 'BundledNETCoreAppTargetFrameworkVersion' to specify the .NET version in the project files.

### DIFF
--- a/MonoTouch.Dialog/dotnet/MacCatalyst/MonoTouch.Dialog.csproj
+++ b/MonoTouch.Dialog/dotnet/MacCatalyst/MonoTouch.Dialog.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-maccatalyst</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/MonoTouch.Dialog/dotnet/iOS/MonoTouch.Dialog.csproj
+++ b/MonoTouch.Dialog/dotnet/iOS/MonoTouch.Dialog.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-ios</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/MonoTouch.Dialog/dotnet/macOS/MonoTouch.Dialog.csproj
+++ b/MonoTouch.Dialog/dotnet/macOS/MonoTouch.Dialog.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-macos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/MonoTouch.Dialog/dotnet/tvOS/MonoTouch.Dialog.csproj
+++ b/MonoTouch.Dialog/dotnet/tvOS/MonoTouch.Dialog.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-tvos</TargetFramework>
+    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>


### PR DESCRIPTION
This way we'll target net6.0-* when building with .NET 6, and net7.0-* when
building with .NET 7.