### PR TITLE
Revert "[MonoTouch.Dialog] Use 'BundledNETCoreAppTargetFrameworkVersion' to specify the .NET version in the project files. (#261)"

### DIFF
--- a/MonoTouch.Dialog/dotnet/MacCatalyst/MonoTouch.Dialog.csproj
+++ b/MonoTouch.Dialog/dotnet/MacCatalyst/MonoTouch.Dialog.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+    <TargetFramework>net6.0-maccatalyst</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/MonoTouch.Dialog/dotnet/iOS/MonoTouch.Dialog.csproj
+++ b/MonoTouch.Dialog/dotnet/iOS/MonoTouch.Dialog.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+    <TargetFramework>net6.0-ios</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/MonoTouch.Dialog/dotnet/macOS/MonoTouch.Dialog.csproj
+++ b/MonoTouch.Dialog/dotnet/macOS/MonoTouch.Dialog.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
+    <TargetFramework>net6.0-macos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>

--- a/MonoTouch.Dialog/dotnet/tvOS/MonoTouch.Dialog.csproj
+++ b/MonoTouch.Dialog/dotnet/tvOS/MonoTouch.Dialog.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
+    <TargetFramework>net6.0-tvos</TargetFramework>
   </PropertyGroup>
   <Import Project="..\shared.csproj" />
 </Project>


### PR DESCRIPTION
This reverts commit 8e859cc66279e6273d97980e28516b73c79d726c.

It won't be needed, using 'net6.0-*' will continue to work in .NET 7+.